### PR TITLE
fix: docker-compose file - remove duplicated `KAFKA_ADVERTISED_HOST_NAME`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,6 @@ services:
       KAFKA_CREATE_TOPICS: openfga-topic:1.1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_ADVERTISED_HOST_NAME: kafka
     depends_on:
       - zookeeper
     healthcheck:


### PR DESCRIPTION
Remove `KAFKA_ADVERTISED_HOST_NAME`, because it already exists at Line 86: https://github.com/embesozzi/keycloak-openfga-workshop/blob/a76b91c4186fd821296d31d32f55d969e7880621/docker-compose.yml#L86